### PR TITLE
Must Match All Receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Each pool config must have a `receivers` property which is a simple Glob that wi
 
 It's important to note, that a receiver can ONLY be apart of one pool. So if two pools have receiver patterns that match the same receiver, then the first defined pool would own that receiver.
 
+### Disabling Must Match All Receivers
+
+By default, the bundle will throw an exception if any receivers are not matched by the pool config. This is to help prevent any unexpected bugs where you the receiver name is for some reason not matched by a pool when you expected it to.
+
+To disable this check, update the `must_match_all_receivers` config option to false:
+
+```yaml
+messenger_auto_scale:
+  must_match_all_receivers: false
+```
+
 ## Configuring Heartbeats
 
 By default, each worker pool will log a heartbeat event every 60 seconds. If you want to change the frequency of that, you use the pool `heartbeat_interval` to define the number of seconds between subsequent heartbeats.

--- a/src/DependencyInjection/BuildSupervisorPoolConfigCompilerPass.php
+++ b/src/DependencyInjection/BuildSupervisorPoolConfigCompilerPass.php
@@ -40,6 +40,10 @@ final class BuildSupervisorPoolConfigCompilerPass implements CompilerPassInterfa
             [$matchedReceiverNames, $receiverNames] = $this->matchReceiverNameFromRawPool($rawPool, $receiverNames);
             yield ['name' => $poolName, 'poolConfig' => $rawPool, 'receiverIds' => $matchedReceiverNames];
         }
+
+        if (count($receiverNames) && $rawPoolConfig['must_match_all_receivers']) {
+            throw new \LogicException('Some receivers were not matched by the pool config: ' . implode(', ', $receiverNames));
+        }
     }
 
     /** return the matched receiver names and unmatched recevier names as a two tuple. */

--- a/src/MessengerAutoScaleBundle.php
+++ b/src/MessengerAutoScaleBundle.php
@@ -2,6 +2,7 @@
 
 namespace Krak\SymfonyMessengerAutoScale;
 
+use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -11,13 +12,13 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\Config\FileLocator;
 use function Krak\Schema\{
+    bool,
     dict,
     struct,
     int,
     listOf,
     string,
-    ProcessSchema\SymfonyConfig\configTree
-};
+    ProcessSchema\SymfonyConfig\configTree};
 
 class MessengerAutoScaleBundle extends Bundle
 {
@@ -52,6 +53,9 @@ class MessengerAutoScaleBundle extends Bundle
                         return configTree('messenger_auto_scale', struct([
                             'console_path' => string(['configure' => function(ScalarNodeDefinition $def) {
                                 $def->defaultValue('%kernel.project_dir%/bin/console');
+                            }]),
+                            'must_match_all_receivers' => bool(['configure' => function(BooleanNodeDefinition $def) {
+                                $def->defaultTrue();
                             }]),
                             'pools' => dict(struct([
                                 'min_procs' => int(),

--- a/tests/Feature/Bundle/InitsKernel.php
+++ b/tests/Feature/Bundle/InitsKernel.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Krak\SymfonyMessengerAutoScale\Tests\Feature\Bundle;
+
+use Krak\SymfonyMessengerAutoScale\MessengerAutoScaleBundle;
+use Krak\SymfonyMessengerAutoScale\Tests\Feature\Fixtures\TestFixtureBundle;
+use Krak\SymfonyMessengerRedis\MessengerRedisBundle;
+use Nyholm\BundleTest\CompilerPass\PublicServicePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+trait InitsKernel
+{
+    protected function getBundleClass() {
+        return MessengerAutoScaleBundle::class;
+    }
+
+    private function registerPublicServiceCompilerPass() {
+        $this->addCompilerPass(new PublicServicePass('/(Krak.*|krak\..*|messenger.default_serializer|message_bus)/'));
+    }
+
+    private function given_the_kernel_is_booted_with_config_resources(array $configResources) {
+        $kernel = $this->createKernel();
+        $kernel->addBundle(TestFixtureBundle::class);
+        $kernel->addBundle(MessengerRedisBundle::class);
+        foreach ($configResources as $config) {
+            $kernel->addConfigFile($config);
+        }
+        $this->bootKernel();
+    }
+
+    private function given_the_kernel_is_booted_with_messenger_and_auto_scale_config() {
+        $this->given_the_kernel_is_booted_with_config_resources([
+            __DIR__ . '/../Fixtures/messenger-config.yaml',
+            __DIR__ . '/../Fixtures/auto-scale-config.yaml',
+        ]);
+    }
+}

--- a/tests/Feature/Bundle/MustMatchAllReceiversTest.php
+++ b/tests/Feature/Bundle/MustMatchAllReceiversTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Krak\SymfonyMessengerAutoScale\Tests\Feature\Bundle;
+
+use Nyholm\BundleTest\BaseBundleTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class MustMatchAllReceiversTest extends BaseBundleTestCase
+{
+    use InitsKernel;
+
+    /** @var \Throwable|null $e */
+    private $exception;
+    private $configs;
+
+
+    protected function setUp() {
+        parent::setUp();
+        $this->registerPublicServiceCompilerPass();
+    }
+
+    /** @test */
+    public function throws_exception_if_not_all_receivers_are_matched() {
+        $this->given_the_config_where_not_all_receivers_are_set_is_available();
+        $this->when_the_kernel_is_booted();
+        $this->then_the_not_matched_logic_exception_is_thrown();
+    }
+
+    /** @test */
+    public function can_disable_must_match_all_receivers_flag() {
+        $this->given_the_config_where_not_all_receivers_are_set_flag_is_disabled();
+        $this->when_the_kernel_is_booted();
+        $this->then_no_exception_is_thrown();
+    }
+
+    private function given_the_config_where_not_all_receivers_are_set_is_available() {
+        $this->configs = [
+            __DIR__ . '/../Fixtures/messenger-config.yaml',
+            __DIR__ . '/../Fixtures/auto-scale-config-with-missing-receivers.yaml',
+        ];
+    }
+
+    private function given_the_config_where_not_all_receivers_are_set_flag_is_disabled() {
+        $this->configs = [
+            __DIR__ . '/../Fixtures/messenger-config.yaml',
+            __DIR__ . '/../Fixtures/auto-scale-config-with-missing-receivers-disabled.yaml'
+        ];
+    }
+
+    private function when_the_kernel_is_booted() {
+        try {
+            $this->given_the_kernel_is_booted_with_config_resources($this->configs);
+        } catch (\Throwable $e) {
+            $this->exception = $e;
+        }
+    }
+
+    private function then_the_not_matched_logic_exception_is_thrown() {
+        $this->assertInstanceOf(\LogicException::class, $this->exception);
+        $this->assertEquals('Some receivers were not matched by the pool config: catalog', $this->exception->getMessage());
+    }
+
+    private function then_no_exception_is_thrown() {
+        $this->assertNull($this->exception);
+    }
+}

--- a/tests/Feature/Fixtures/auto-scale-config-with-missing-receivers-disabled.yaml
+++ b/tests/Feature/Fixtures/auto-scale-config-with-missing-receivers-disabled.yaml
@@ -1,0 +1,5 @@
+messenger_auto_scale:
+  must_match_all_receivers: false
+  pools:
+    sales:
+      receivers: "sales*"

--- a/tests/Feature/Fixtures/auto-scale-config-with-missing-receivers.yaml
+++ b/tests/Feature/Fixtures/auto-scale-config-with-missing-receivers.yaml
@@ -1,0 +1,4 @@
+messenger_auto_scale:
+  pools:
+    sales:
+      receivers: "sales*"


### PR DESCRIPTION
- Added new feature which will enforce that all
  receivers are matched to help prevent any bugs
  on receiver patterns or typos

Signed-off-by: RJ Garcia <ragboyjr@icloud.com>